### PR TITLE
Add German translation

### DIFF
--- a/custom_components/miele/translations/de.json
+++ b/custom_components/miele/translations/de.json
@@ -1,0 +1,32 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Konto ist bereits konfiguriert",
+            "already_in_progress": "Konfigurationsfluss bereits im Gange",
+            "authorize_url_timeout": "Zeitüberschreitung beim Erzeugen der Autorisierungs-URL.",
+            "missing_configuration": "Die Komponente ist nicht konfiguriert. Bitte folge der Anleitung.",
+            "no_url_available": "Keine URL verfügbar. Für Informationen zu diesem Fehler, [überprüfe den Hilfe-Abschnitt]({docs_url})",
+            "oauth_error": "Ungültige Token-Daten erhalten.",
+            "reauth_successful": "Die Neuauthentifizierung war erfolgreich"
+        },
+        "create_entry": {
+            "default": "Erfolgreich authentifiziert"
+        },
+        "step": {
+            "pick_implementation": {
+                "title": "Authentifizierungsmethode auswählen"
+            },
+            "reauth_confirm": {
+              "title": "Neuauthentifizierung erforderlich",
+              "description": "Die Miele-Integration muss deinen Account neu authentifizieren: {account}"
+            }
+        }
+    }    ,
+    "system_health": {
+      "info": {
+        "reach_miele_cloud": "Erreichbarkeit Miele-Cloud",
+        "component_version": "Version",
+        "connected2stream": "Verbunden mit signalr"
+      }
+    }
+  }

--- a/custom_components/miele/translations/sensor.de.json
+++ b/custom_components/miele/translations/sensor.de.json
@@ -1,0 +1,72 @@
+{
+    "state": {
+      "miele__state_status": {
+        "off": "Aus",
+        "on": "Ein",
+        "programmed": "Programmiert",
+        "programmed_waiting_to_start": "Start verzögert",
+        "running": "In Betrieb",
+        "pause": "Pause",
+        "end_programmed": "Ende",
+        "failure": "Fehler",
+        "programme_interrupted": "Programm unterbrochen",
+        "idle": "Untätig",
+        "rinse_hold": "Spülstop",
+        "service": "Service",
+        "superfreezing": "SuperFrost",
+        "supercooling": "SuperKühlen",
+        "superheating": "Schnellaufheizen",
+        "supercooling_superfreezing": "SuperKühlen/SuperFrost",
+        "not_connected": "Nicht verbunden"
+      },
+      "miele__state_program_type": {
+        "normal_operation_mode": "Normalbetrieb",
+        "own_program": "Eigenes Programm",
+        "automatic_program": "Automatik-Programm",
+        "cleaning_care_program": "Reinigungs-/Pflege-Programm"
+      },
+      "miele__state_program_id": {
+        "cottons": "Baumwolle",
+        "minimum_iron": "Vorbügeln",
+        "quick_power_wash": "QuickPowerWash"
+      },
+      "miele__state_program_phase": {
+        "not_running": "Nicht in Betrieb",
+        "main_wash": "Hauptwaschgang",
+        "drying": "Trocknen",
+        "pre_wash": "Vorwäsche",
+        "soak": "Einweichen",
+        "rinse": "Spülen",
+        "rinse_hold": "Spülstop",
+        "cooling_down": "Abkühlen",
+        "drain": "Ablaufen",
+        "spin": "Schleudern",
+        "anti_crease": "Knitterschutz",
+        "finished": "Fertig",
+        "venting": "Entlüften",
+        "starch_stop": "Stärkestop",
+        "freshen_up_and_moisten": "Auffrischen + Befeuchten",
+        "steam_smoothing": "Dampfglätten",
+        "hygiene": "Hygiene",
+        "disinfecting": "Desinfektion",
+        "program_running": "Programm läuft",
+        "machine_iron": "Mangelfeucht",
+        "hand_iron": "Bügelfeucht",
+        "normal": "Schranktrocken",
+        "normal_plus": "Schranktrocken+",
+        "extra_dry": "Extratrocken",
+        "moisten": "Befeuchten",
+        "timed_drying": "Zeitgesteuertes Trocknen",
+        "warm_air": "Warme Luft",
+        "comfort_cooling": "Komfortkühlung",
+        "rinse_out_lint": "Flusen ausspülen",
+        "rinses": "Spülgänge",
+        "smoothing": "Glätten",
+        "slightly_dry": "Leichttrocken",
+        "safety_cooling": "Sicherheitskühlung",
+        "reactivating": "Reaktivieren",
+        "interim_rinse": "Zwischenspülen",
+        "final_rinse": "Abschließender Spülgang"
+      }
+   }
+}


### PR DESCRIPTION
Adds German translation.

Note: I'm not totally sure what the best translation for "Supercooling" and "Superheating" is (Superfreezing is definitely "SuperFrost", a named feature/trademark). There is a named feature/trademark "SuperKühlen", but I fewer people know about it ("SuperFrost" and similarly named features are pretty much standard for high quality freezers, regardless of manufacturer). [IPSymcon uses "Schnellkühlen" and "Schnellaufheizen"](https://github.com/demel42/IPSymconMieleAtHome/blob/master/MielelAtHomeDevice/locale.json) ("fast cooling" and "fast heating"), which is more descriptive. There does not appear to be a named feature/trademark equivalent to "Superheating" on the German Miele site at this point.