### PR TITLE
Services and improved diagnostics

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -27,6 +27,7 @@ from . import config_flow
 from .api import AsyncConfigEntryAuth
 from .const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 from .devcap import TEST_DATA_7, TEST_DATA_24
+from .services import async_setup_services
 
 # from .pymiele import MieleAuthException
 
@@ -142,6 +143,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await async_setup_services(hass)
+
     return True
 
 

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -135,10 +135,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             flat_result[ent] = dict(flatdict.FlatterDict(data[ent], delimiter="|"))
         coordinator.async_set_updated_data(flat_result)
 
+    async def _callback_update_actions(data) -> None:
+        hass.data[DOMAIN][entry.entry_id]["actions"] = data
+
     hass.data[DOMAIN][entry.entry_id]["listener"] = asyncio.create_task(
         hass.data[DOMAIN][entry.entry_id]["api"].listen_events(
             data_callback=_callback_update_data,
-            # effects_callback=_callback_update_light_state,
+            actions_callback=_callback_update_actions,
         )
     )
 

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -191,7 +191,7 @@ async def get_coordinator(
         logging.getLogger(__name__),
         name=DOMAIN,
         update_method=async_fetch,
-        update_interval=timedelta(seconds=30),
+        update_interval=timedelta(seconds=60),
     )
     await hass.data[DOMAIN][entry.entry_id]["coordinator"].async_refresh()
     return hass.data[DOMAIN][entry.entry_id]["coordinator"]

--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -151,3 +151,13 @@ APPLIANCE_TYPES = {
     DIALOG_OVEN: "dialog_oven",
     WINE_CABINET_FREEZER: "wine_cabinet_freezer",
 }
+
+PROCESS_ACTIONS = {
+    "start": 1,
+    "stop": 2,
+    "pause": 3,
+    "start_superfreezing": 4,
+    "stop_superfreezing": 5,
+    "start_supercooling": 6,
+    "stop_supercooling": 7,
+}

--- a/custom_components/miele/diagnostics.py
+++ b/custom_components/miele/diagnostics.py
@@ -36,7 +36,9 @@ async def async_get_config_entry_diagnostics(
         ino += 1
         device_data[f"Appliance_{ino}"] = coordinator.data[key]
         if "actions" in hass.data[DOMAIN][config_entry.entry_id]:
-          action_data[f"Appliance_{ino}"] = hass.data[DOMAIN][config_entry.entry_id]["actions"][key]
+            action_data[f"Appliance_{ino}"] = hass.data[DOMAIN][config_entry.entry_id][
+                "actions"
+            ][key]
 
     diagnostics_data = {
         "info": async_redact_data(config_entry.data, TO_REDACT),
@@ -65,7 +67,7 @@ async def async_get_device_diagnostics(
         if ("miele", key) in device.identifiers:
             device_data = coordinator.data[key]
             if "actions" in hass.data[DOMAIN][config_entry.entry_id]:
-              action_data = hass.data[DOMAIN][config_entry.entry_id]["actions"][key]
+                action_data = hass.data[DOMAIN][config_entry.entry_id]["actions"][key]
 
     diagnostics_data = {
         "info": async_redact_data(info, TO_REDACT),

--- a/custom_components/miele/diagnostics.py
+++ b/custom_components/miele/diagnostics.py
@@ -30,14 +30,18 @@ async def async_get_config_entry_diagnostics(
     ]
 
     device_data = {}
+    action_data = {}
     ino = 0
     for val, key in enumerate(coordinator.data):
         ino += 1
         device_data[f"Appliance_{ino}"] = coordinator.data[key]
+        if "actions" in hass.data[DOMAIN][config_entry.entry_id]:
+          action_data[f"Appliance_{ino}"] = hass.data[DOMAIN][config_entry.entry_id]["actions"][key]
 
     diagnostics_data = {
         "info": async_redact_data(config_entry.data, TO_REDACT),
         "data": async_redact_data(device_data, TO_REDACT),
+        "actions": async_redact_data(action_data, TO_REDACT),
     }
 
     return diagnostics_data
@@ -56,13 +60,17 @@ async def async_get_device_diagnostics(
     ]
 
     device_data = {}
+    action_data = {}
     for val, key in enumerate(coordinator.data):
         if ("miele", key) in device.identifiers:
             device_data = coordinator.data[key]
+            if "actions" in hass.data[DOMAIN][config_entry.entry_id]:
+              action_data = hass.data[DOMAIN][config_entry.entry_id]["actions"][key]
 
     diagnostics_data = {
         "info": async_redact_data(info, TO_REDACT),
         "data": async_redact_data(device_data, TO_REDACT),
+        "actions": async_redact_data(action_data, TO_REDACT),
     }
 
     return diagnostics_data

--- a/custom_components/miele/services.py
+++ b/custom_components/miele/services.py
@@ -1,0 +1,59 @@
+"""Services for Miele integration."""
+
+import logging
+
+import aiohttp
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.service import async_extract_config_entry_ids
+
+from .const import DOMAIN, PROCESS_ACTIONS
+
+SERVICE_PROCESS_ACTION = cv.make_entity_service_schema(
+    {
+        vol.Required("action"): cv.string,
+    },
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    async def extract_our_config_entry_ids(service_call: ServiceCall):
+        return [
+            entry_id
+            for entry_id in await async_extract_config_entry_ids(hass, service_call)
+            if (entry := hass.config_entries.async_get_entry(entry_id))
+            and entry.domain == DOMAIN
+        ]
+
+    async def send_process_action(call: ServiceCall):
+        _LOGGER.debug("Call: %s", call)
+        if not (our_entry_ids := await extract_our_config_entry_ids(call)):
+            raise HomeAssistantError(
+                "Failed to call service 'process_action'. Config entry for target not found"
+            )
+        _LOGGER.debug("Entries: %s", our_entry_ids)
+        device_reg = device_registry.async_get(hass)
+        for ent in call.data["device_id"]:
+            device_entry = device_reg.async_get(ent)
+            for ident in device_entry.identifiers:
+                for val in ident:
+                    if val != DOMAIN:
+                        serno = val
+
+            _api = hass.data[DOMAIN][our_entry_ids[0]]["api"]
+            act = PROCESS_ACTIONS[call.data["action"]]
+            try:
+                await _api.send_action(serno, {"processAction": act})
+            except aiohttp.ClientResponseError as ex:
+                _LOGGER.error("Service process_action: %s - %s", ex.status, ex.message)
+        return
+
+    hass.services.async_register(
+        DOMAIN, "process_action", send_process_action, SERVICE_PROCESS_ACTION
+    )
+    return

--- a/custom_components/miele/services.py
+++ b/custom_components/miele/services.py
@@ -14,7 +14,7 @@ from .const import DOMAIN, PROCESS_ACTIONS
 
 SERVICE_PROCESS_ACTION = cv.make_entity_service_schema(
     {
-        vol.Required("action"): cv.string,
+        vol.Required("action"): vol.In(PROCESS_ACTIONS),
     },
 )
 

--- a/custom_components/miele/services.yaml
+++ b/custom_components/miele/services.yaml
@@ -1,0 +1,36 @@
+# Services descriptions for Miele
+
+process_action:
+  name: Execute process action
+  description: Executes process action if preconditions are met.
+  # If the service accepts entity IDs, target allows the user to specify entities by entity, device, or area.
+  # If `target` is specified, `entity_id` should not be defined in the `fields` map.
+  # By default it shows only targets matching entities from the same domain as the service,
+  # but if further customization is required, target supports the entity, device, and area selectors (https://www.home-assistant.io/docs/blueprint/selectors/).
+  # Entity selector parameters will automatically be applied to device and area, and device selector parameters will automatically be applied to area.
+  target:
+    device:
+      integration: "miele"
+
+  fields:
+    action:
+      # Field name as shown in UI
+      name: Action
+      description: processAction
+      required: true
+      advanced: false
+      # Example value that can be passed for this field
+      example: "start"
+      # The default field value
+      default: ""
+      # Selector (https://www.home-assistant.io/docs/blueprint/selectors/) to control the input UI for this field
+      selector:
+        select:
+          options:
+            - "start"
+            - "stop"
+            - "pause"
+            - "start_superfreezing"
+            - "stop_superfreezing"
+            - "start_supercooling"
+            - "stop_supercooling"


### PR DESCRIPTION
### Improved diagnostics 
Data from the `/actions` endpoint is included in the download
### Services
Setting of processAction is added as a starter. There are still missing a few guards for parameter errors. However if you use correct syntax in the service call everything works as expected. The service call can be tested from Developer Tools->Services: `Miele Execute process action`
### Misc
Set background update interval to 60 sec.