### PR TITLE
Add generic and raw service

### DIFF
--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -177,3 +177,15 @@ PROCESS_ACTIONS = {
     "start_supercooling": 6,
     "stop_supercooling": 7,
 }
+
+AMBIENT_COLORS = {
+    "white",
+    "blue",
+    "red",
+    "yellow",
+    "orange",
+    "green",
+    "pink",
+    "purple",
+    "turquoise",
+}

--- a/custom_components/miele/services.py
+++ b/custom_components/miele/services.py
@@ -1,5 +1,6 @@
 """Services for Miele integration."""
 
+import copy
 import logging
 
 import aiohttp
@@ -10,12 +11,34 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.service import async_extract_config_entry_ids
 
-from .const import DOMAIN, PROCESS_ACTIONS
+from .const import AMBIENT_COLORS, DOMAIN, PROCESS_ACTIONS
 
 SERVICE_PROCESS_ACTION = cv.make_entity_service_schema(
     {
         vol.Required("action"): vol.In(PROCESS_ACTIONS),
     },
+)
+
+SERVICE_GENERIC_ACTION = cv.make_entity_service_schema(
+    {
+        vol.Optional("processAction"): vol.All(int, vol.Range(min=1, max=10)),
+        vol.Optional("light"): vol.All(int, vol.Range(min=1, max=2)),
+        vol.Optional("startTime"): list,
+        vol.Optional("programId"): cv.positive_int,
+        vol.Optional("targetTemperature"): dict,
+        vol.Optional("deviceName"): cv.string,
+        vol.Optional("powerOn"): cv.boolean,
+        vol.Optional("powerOff"): cv.boolean,
+        vol.Optional("colors"): vol.In(AMBIENT_COLORS),
+        vol.Optional("modes"): cv.positive_int,
+    },
+)
+
+SERVICE_RAW = vol.Schema(
+    {
+        vol.Required("serialno"): cv.string,
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,10 +73,56 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             try:
                 await _api.send_action(serno, {"processAction": act})
             except aiohttp.ClientResponseError as ex:
-                _LOGGER.error("Service process_action: %s - %s", ex.status, ex.message)
+                raise HomeAssistantError(
+                    f"Service generic_action: {ex.status} {ex.message}"
+                )
+        return
+
+    async def send_generic_action(call: ServiceCall):
+        _LOGGER.debug("Call: %s", call)
+        if not (our_entry_ids := await extract_our_config_entry_ids(call)):
+            raise HomeAssistantError(
+                "Failed to call service 'generic_action'. Config entry for target not found"
+            )
+        _LOGGER.debug("Entries: %s", our_entry_ids)
+        device_reg = device_registry.async_get(hass)
+        for ent in call.data["device_id"]:
+            device_entry = device_reg.async_get(ent)
+            for ident in device_entry.identifiers:
+                for val in ident:
+                    if val != DOMAIN:
+                        serno = val
+
+            _api = hass.data[DOMAIN][our_entry_ids[0]]["api"]
+            data = copy(call.data)
+            data = data.pop("entity_id")
+            try:
+                await _api.send_action(serno, data)
+            except aiohttp.ClientResponseError as ex:
+                raise HomeAssistantError(
+                    f"Service generic_action: {ex.status} {ex.message}"
+                )
+        return
+
+    async def send_raw(call: ServiceCall):
+        _LOGGER.debug("Call: %s", call)
+        account = list(hass.data[DOMAIN].keys())[0]
+        _api = hass.data[DOMAIN][account]["api"]
+        try:
+            await _api.send_action(call.data["serialno"], call.data["extra"])
+        except aiohttp.ClientResponseError as ex:
+            raise HomeAssistantError(
+                f"Service raw: {ex.status} {ex.message}"
+            )
         return
 
     hass.services.async_register(
         DOMAIN, "process_action", send_process_action, SERVICE_PROCESS_ACTION
+    )
+    hass.services.async_register(
+        DOMAIN, "generic_action", send_generic_action, SERVICE_GENERIC_ACTION
+    )
+    hass.services.async_register(
+        DOMAIN, "raw", send_raw, SERVICE_RAW
     )
     return

--- a/custom_components/miele/services.yaml
+++ b/custom_components/miele/services.yaml
@@ -62,6 +62,7 @@ generic_action:
       example: true
     colors:
       example: "blue"
+      description: Set color of ambient light
     modes:
       example: 1
 

--- a/custom_components/miele/services.yaml
+++ b/custom_components/miele/services.yaml
@@ -34,3 +34,44 @@ process_action:
             - "stop_superfreezing"
             - "start_supercooling"
             - "stop_supercooling"
+
+generic_action:
+  name: Execute generic action
+  description: Executes service with limited validation of commands and parameters. Only send one parameter per service call.
+  target:
+    device:
+      integration: "miele"
+  fields:
+    processAction:
+      example: 1
+    light:
+      example: 1
+    startTime:
+      example: "[1, 30]"
+    ventilationStep:
+      example: 1
+    programId:
+      example: 24
+    targetTemperature:
+      example: '[{ "zone": 1, "value": 5 }]'
+    deviceName:
+      example: "A new name"
+    powerOn:
+      example: true
+    powerOff:
+      example: true
+    colors:
+      example: "blue"
+    modes:
+      example: 1
+
+raw:
+  name: Execute raw action
+  description: Execute service with minmal validation.
+  fields:
+    serialno:
+      description: The serial number of the appliance
+      example: "123456"
+    extra:
+      description: A dictionary with parameters
+      example: '{ "targetTemperature": [{"zone": 1, "value": -18 }] }'

--- a/custom_components/miele/services.yaml
+++ b/custom_components/miele/services.yaml
@@ -44,26 +44,36 @@ generic_action:
   fields:
     processAction:
       example: 1
+      description: Set processAction
     light:
+      description: Set light on or off
       example: 1
     startTime:
+      description: Set start time
       example: "[1, 30]"
     ventilationStep:
+      description: Select ventilation step
       example: 1
     programId:
+      description: Set program
       example: 24
     targetTemperature:
+      description: Set target temperature
       example: '[{ "zone": 1, "value": 5 }]'
     deviceName:
+      description: Rename device
       example: "A new name"
     powerOn:
+      description: Power on appliance
       example: true
     powerOff:
+      description: Power off appliance
       example: true
     colors:
       example: "blue"
       description: Set color of ambient light
     modes:
+      description: Set mode
       example: 1
 
 raw:


### PR DESCRIPTION
The raw service requires the serial number for your appliance and willl allow you to construct a payload without validation in the integration. However, each service must fulfill some preconditions. These are enforced by the API at Miele and error messages will be logged if the API did not accept the service call.

The generic service has some more validation built in but is considered as Work In Progress.

All services can be tested on developer tools page.

Closes #25 