### PR TITLE
Use actions data for setup

### DIFF
--- a/custom_components/miele/climate.py
+++ b/custom_components/miele/climate.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.update_coordinator import (
 
 from . import get_coordinator
 from .const import DOMAIN
-from .devcap import LIVE_ACTION_CAPABILITIES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,12 +123,12 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
         self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
         self._attr_temperature_unit = self.entity_description.temperature_unit
         self._attr_precision = self.entity_description.precision
-        self._attr_max_temp = LIVE_ACTION_CAPABILITIES[self._ent]["targetTemperature"][
-            0
-        ]["max"]
-        self._attr_min_temp = LIVE_ACTION_CAPABILITIES[self._ent]["targetTemperature"][
-            0
-        ]["min"]
+        self._attr_max_temp = hass.data[DOMAIN][entry.entry_id]["actions"][self._ent][
+            "targetTemperature"
+        ][0]["max"]
+        self._attr_min_temp = hass.data[DOMAIN][entry.entry_id]["actions"][self._ent][
+            "targetTemperature"
+        ][0]["min"]
         self._attr_target_temperature_step = (
             self.entity_description.target_temperature_step
         )

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -105,7 +105,6 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             native_unit_of_measurement=TEMP_CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x: x / 100.0,
-            extra_attributes={"Raw value": 0},
         ),
     ),
     MieleSensorDefinition(
@@ -134,7 +133,6 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             native_unit_of_measurement=TEMP_CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x: x / 100.0,
-            extra_attributes={"Raw value": 0},
             entity_registry_enabled_default=False,
         ),
     ),
@@ -164,7 +162,6 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             native_unit_of_measurement=TEMP_CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x: x / 100.0,
-            extra_attributes={"Raw value": 0},
             entity_registry_enabled_default=False,
         ),
     ),
@@ -297,8 +294,8 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             name="Status",
             device_class="miele__state_status",
             icon="mdi:state-machine",
-            # entity_category=EntityCategory.DIAGNOSTIC,
             convert=lambda x: STATE_STATUS.get(x, x),
+            extra_attributes={"Raw value": 0},
         ),
     ),
     MieleSensorDefinition(


### PR DESCRIPTION
Collect /devices/{serial}/actions for each device during setup, fixes #24 