### PR TITLE
Fix English "translation" key for program_ended

### DIFF
--- a/custom_components/miele/translations/sensor.en.json
+++ b/custom_components/miele/translations/sensor.en.json
@@ -7,7 +7,7 @@
       "programmed_waiting_to_start": "Programmed waiting to start",
       "running": "Running",
       "pause": "Pause",
-      "end_programmed": "Program ended",
+      "program_ended": "Program ended",
       "failure": "Failure",
       "program_interrupted": "Program interrupted",
       "idle": "Idle",


### PR DESCRIPTION
`end_programmed` was not changed to `program_ended` in the English translation file.