### PR TITLE
Further simplify state strings

### DIFF
--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -12,7 +12,7 @@ STATE_STATUS = {
     1: "off",
     2: "on",
     3: "programmed",
-    4: "programmed_waiting_to_start",
+    4: "waiting_to_start",
     5: "running",
     6: "pause",
     7: "program_ended",

--- a/custom_components/miele/translations/sensor.de.json
+++ b/custom_components/miele/translations/sensor.de.json
@@ -4,7 +4,7 @@
         "off": "Aus",
         "on": "Ein",
         "programmed": "Programmiert",
-        "programmed_waiting_to_start": "Start verzögert",
+        "waiting_to_start": "Start verzögert",
         "running": "In Betrieb",
         "pause": "Pause",
         "program_ended": "Ende",

--- a/custom_components/miele/translations/sensor.en.json
+++ b/custom_components/miele/translations/sensor.en.json
@@ -4,7 +4,7 @@
       "off": "Off",
       "on": "On",
       "programmed": "Programmed",
-      "programmed_waiting_to_start": "Programmed waiting to start",
+      "waiting_to_start": "Waiting to start",
       "running": "Running",
       "pause": "Pause",
       "program_ended": "Program ended",

--- a/custom_components/miele/translations/sensor.sv.json
+++ b/custom_components/miele/translations/sensor.sv.json
@@ -4,7 +4,7 @@
       "off": "Från",
       "on": "Till",
       "programmed": "Programmerad",
-      "programmed_waiting_to_start": "Programmerad väntar på start",
+      "waiting_to_start": "Programmerad väntar på start",
       "running": "Igång",
       "pause": "Pause",
       "program_ended": "Program slut",


### PR DESCRIPTION
Miele now (?) uses "Waiting to start" in their API, so I think we can simplify the technical state string as well.

Possible TODO: Changing the Swedish translation.