### PR TITLE
Support 3 zones in freezers and fridges

### DIFF
--- a/custom_components/miele/climate.py
+++ b/custom_components/miele/climate.py
@@ -41,6 +41,7 @@ class MieleClimateDescription(ClimateEntityDescription):
     min_temp: float | None = None
     target_temperature_step: float | None = None
     hvac_modes: list | None = None
+    zone: int = 0
     supported_features: int = 0
 
 
@@ -65,6 +66,39 @@ CLIMATE_TYPES: Final[tuple[MieleClimateDefinition, ...]] = (
             precision=1.0,
             target_temperature_step=1.0,
             hvac_modes=[HVAC_MODE_COOL],
+            zone=0,
+            supported_features=SUPPORT_TARGET_TEMPERATURE,
+        ),
+    ),
+    MieleClimateDefinition(
+        types=[19, 20, 21, 32, 33, 34, 68],
+        description=MieleClimateDescription(
+            key="thermostat",
+            currentTemperature_tag="state|temperature|1|value_raw",
+            targetTemperature_tag="state|targetTemperature|1|value_raw",
+            type_key="ident|type|value_localized",
+            name="Zone 2",
+            temperature_unit=TEMP_CELSIUS,
+            precision=1.0,
+            target_temperature_step=1.0,
+            hvac_modes=[HVAC_MODE_COOL],
+            zone=1,
+            supported_features=SUPPORT_TARGET_TEMPERATURE,
+        ),
+    ),
+    MieleClimateDefinition(
+        types=[19, 20, 21, 32, 33, 34, 68],
+        description=MieleClimateDescription(
+            key="thermostat",
+            currentTemperature_tag="state|temperature|2|value_raw",
+            targetTemperature_tag="state|targetTemperature|2|value_raw",
+            type_key="ident|type|value_localized",
+            name="Zone 3",
+            temperature_unit=TEMP_CELSIUS,
+            precision=1.0,
+            target_temperature_step=1.0,
+            hvac_modes=[HVAC_MODE_COOL],
+            zone=2,
             supported_features=SUPPORT_TARGET_TEMPERATURE,
         ),
     ),
@@ -82,7 +116,11 @@ async def async_setup_entry(
     entities = []
     for idx, ent in enumerate(coordinator.data):
         for definition in CLIMATE_TYPES:
-            if coordinator.data[ent]["ident|type|value_raw"] in definition.types:
+            if (
+                coordinator.data[ent]["ident|type|value_raw"] in definition.types
+                and coordinator.data[ent][definition.description.targetTemperature_tag]
+                != -32768
+            ):
                 entities.append(
                     MieleClimate(
                         coordinator,
@@ -113,31 +151,32 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._api = hass.data[DOMAIN][entry.entry_id]["api"]
+        self._eid = hass.data[DOMAIN][entry.entry_id]
+        self._api = self._eid["api"]
 
         self._idx = idx
         self._ent = ent
-        self.entity_description = description
+        self._ed = description
         _LOGGER.debug("init sensor %s", ent)
-        self._attr_name = f"{self.coordinator.data[self._ent][self.entity_description.type_key]} {self.entity_description.name}"
-        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
-        self._attr_temperature_unit = self.entity_description.temperature_unit
-        self._attr_precision = self.entity_description.precision
-        self._attr_max_temp = hass.data[DOMAIN][entry.entry_id]["actions"][self._ent][
-            "targetTemperature"
-        ][0]["max"]
-        self._attr_min_temp = hass.data[DOMAIN][entry.entry_id]["actions"][self._ent][
-            "targetTemperature"
-        ][0]["min"]
-        self._attr_target_temperature_step = (
-            self.entity_description.target_temperature_step
+        self._attr_name = (
+            f"{self.coordinator.data[self._ent][self._ed.type_key]} {self._ed.name}"
         )
-        self._attr_hvac_modes = self.entity_description.hvac_modes
+        self._attr_unique_id = f"{self._ed.key}-{self._ent}"
+        self._attr_temperature_unit = self._ed.temperature_unit
+        self._attr_precision = self._ed.precision
+        self._attr_max_temp = self._eid["actions"][self._ent]["targetTemperature"][
+            self._ed.zone
+        ]["max"]
+        self._attr_min_temp = self._eid["actions"][self._ent]["targetTemperature"][
+            self._ed.zone
+        ]["min"]
+        self._attr_target_temperature_step = self._ed.target_temperature_step
+        self._attr_hvac_modes = self._ed.hvac_modes
         self._attr_hvac_mode = HVAC_MODE_COOL
-        self._attr_supported_features = self.entity_description.supported_features
+        self._attr_supported_features = self._ed.supported_features
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ent)},
-            name=self.coordinator.data[self._ent][self.entity_description.type_key],
+            name=self.coordinator.data[self._ent][self._ed.type_key],
             manufacturer="Miele",
             model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
         )
@@ -146,10 +185,7 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
     def current_temperature(self):
         """Return the state of the sensor."""
         return round(
-            self.coordinator.data[self._ent][
-                self.entity_description.currentTemperature_tag
-            ]
-            / 100,
+            self.coordinator.data[self._ent][self._ed.currentTemperature_tag] / 100,
             1,
         )
 
@@ -157,10 +193,7 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
     def target_temperature(self):
         """Return the state of the sensor."""
         return round(
-            self.coordinator.data[self._ent][
-                self.entity_description.targetTemperature_tag
-            ]
-            / 100,
+            self.coordinator.data[self._ent][self._ed.targetTemperature_tag] / 100,
             1,
         )
 
@@ -169,7 +202,9 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
         _LOGGER.debug("kwargs: %s", kwargs)
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
             return
-        await self._api.set_target_temperature(self._ent, temperature)
+        await self._api.set_target_temperature(
+            self._ent, temperature, self._ed.zone + 1
+        )
         await self.coordinator.async_request_refresh()
 
     @property


### PR DESCRIPTION
Climate entity is created also for zone 2 and 3 in freezers and fridges if supported. Fixes #30