### PR TITLE
Target temp can be unknown

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -30,6 +30,7 @@ from .const import ACTIONS, API, DOMAIN
 from .devcap import (  # noqa: F401
     TEST_ACTION_21,
     TEST_ACTION_23,
+    TEST_DATA_1,
     TEST_DATA_7,
     TEST_DATA_18,
     TEST_DATA_21,
@@ -174,6 +175,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _callback_update_data(data) -> None:
         # _LOGGER.debug("Callback data: %s", data)
+        # data["1223001"] = TEST_DATA_1
         # data["1223007"] = TEST_DATA_7
         # data["1223018"] = TEST_DATA_18
         # data["1223021"] = TEST_DATA_21
@@ -232,6 +234,7 @@ async def get_coordinator(
             raise ConfigEntryAuthFailed("Authentication failure when fetching data")
         result = await res.json()
         flat_result: dict = {}
+        # result["1223001"] = TEST_DATA_1
         # result["1223007"] = TEST_DATA_7
         # result["1223018"] = TEST_DATA_18
         # result["1223021"] = TEST_DATA_21

--- a/custom_components/miele/climate.py
+++ b/custom_components/miele/climate.py
@@ -220,6 +220,8 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
     @property
     def target_temperature(self):
         """Return the target temperature."""
+        if self.coordinator.data[self._ent][self._ed.targetTemperature_tag] == -32766:
+            return None
         return round(
             self.coordinator.data[self._ent][self._ed.targetTemperature_tag] / 100,
             1,

--- a/custom_components/miele/devcap.py
+++ b/custom_components/miele/devcap.py
@@ -72,6 +72,93 @@ LIVE_ACTION_CAPABILITIES = {
     },
 }
 
+TEST_DATA_1 = {
+    "ident": {
+        "type": {
+            "key_localized": "Device type",
+            "value_raw": 1,
+            "value_localized": "Washing machine",
+        },
+        "deviceName": "",
+        "protocolVersion": 4,
+        "deviceIdentLabel": {
+            "fabNumber": "<fabnumber01>",
+            "fabIndex": "00",
+            "techType": "WWI860",
+            "matNumber": "",
+            "swids": ["000"],
+        },
+        "xkmIdentLabel": {
+            "techType": "EK057",
+            "releaseVersion": "08.15",
+        },
+    },
+    "state": {
+        "ProgramID": {
+            "value_raw": 1,
+            "value_localized": "Cottons",
+            "key_localized": "Program name",
+        },
+        "status": {
+            "value_raw": 1,
+            "value_localized": "Off",
+            "key_localized": "status",
+        },
+        "programType": {
+            "value_raw": 1,
+            "value_localized": "Own programme",
+            "key_localized": "Program type",
+        },
+        "programPhase": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program phase",
+        },
+        "remainingTime": [0, 0],
+        "startTime": [0, 0],
+        "targetTemperature": [
+            {"value_raw": -32766, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "temperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "signalInfo": False,
+        "signalFailure": False,
+        "signalDoor": True,
+        "remoteEnable": {
+            "fullRemoteControl": True,
+            "smartGrid": False,
+            "mobileStart": False,
+        },
+        "ambientLight": None,
+        "light": None,
+        "elapsedTime": [0,0],
+        "spinningSpeed": {
+            "unit": "rpm",
+            "value_raw": 1600,
+            "value_localized": "1600",
+            "key_localized": "Spin speed",
+        },
+        "dryingStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Drying level",
+        },
+        "ventilationStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Fan level",
+        },
+        "plateStep": [],
+        "ecoFeedback": None,
+        "batteryLevel": None,
+    },
+}
+
 TEST_DATA_7 = {
     "ident": {
         "type": {

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -743,6 +743,8 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
             self.coordinator.data[self._ent].get(self.entity_description.data_tag)
             is None
             or self.coordinator.data[self._ent][self.entity_description.data_tag]
+            == -32766
+            or self.coordinator.data[self._ent][self.entity_description.data_tag]
             == -32768
         ):
             return None


### PR DESCRIPTION
When washing mashine runs on `cold` temperature the API reports -32766. This is now displayed as `unknown`.
Fixes #143