### PR TITLE
Possible fix for slow Miele api

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -239,7 +239,7 @@ async def get_coordinator(
     async def async_fetch():
         miele_api = hass.data[DOMAIN][entry.entry_id][API]
         try:
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(20):
                 res = await miele_api.request("GET", "/devices")
             if res.status == 401:
                 raise ConfigEntryAuthFailed("Authentication failure when fetching data")

--- a/custom_components/miele/diagnostics.py
+++ b/custom_components/miele/diagnostics.py
@@ -75,7 +75,7 @@ async def async_get_device_diagnostics(
                     key, {}
                 )
             miele_api = hass.data[DOMAIN][config_entry.entry_id][API]
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(20):
                 res = await miele_api.request("GET", f"/devices/{key}/programs")
             if res.status >= 300:
                 program_data = {"httpStatus": res.status}


### PR DESCRIPTION
```
2022-12-06 18:11:04.003 WARNING (MainThread) [custom_components.miele] Timeout during coordinator fetch
2022-12-06 18:11:04.009 ERROR (MainThread) [custom_components.miele] Error fetching miele data: 
2022-12-06 18:11:04.012 DEBUG (MainThread) [custom_components.miele] Finished fetching miele data in 10.011 seconds (success: False)
2022-12-06 18:12:04.100 INFO (MainThread) [custom_components.miele] Fetching miele data recovered
2022-12-06 18:12:04.101 DEBUG (MainThread) [custom_components.miele] Finished fetching miele data in 0.098 seconds (success: True)
2022-12-06 18:13:04.096 DEBUG (MainThread) [custom_components.miele] Finished fetching miele data in 0.094 seconds (success: True)
2022-12-06 18:14:04.242 DEBUG (MainThread) [custom_components.miele] Finished fetching miele data in 0.241 seconds (success: True)
2022-12-06 18:15:04.103 DEBUG (MainThread) [custom_components.miele] Finished fetching miele data in 0.102 seconds (success: True)
```

It appears that there is some form of flooding and/or flood-control on the Miele side of the API (mostly slightly above 10 seconds).
Increasing the async timeout might fix this.
