### PR TITLE
Add core temperature sensors to ovens

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -645,7 +645,6 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             icon="mdi:thermometer-check",
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x, t: x / 100.0,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -13,11 +13,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
-    TEMP_CELSIUS,
     TIME_MINUTES,
-    VOLUME_LITERS,
+    UnitOfEnergy,
+    UnitOfTemperature,
+    UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -110,7 +110,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|temperature|0|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Temperature",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x, t: x / 100.0,
         ),
@@ -137,7 +137,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|temperature|1|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Temperature zone 2",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x, t: x / 100.0,
             entity_registry_enabled_default=False,
@@ -165,7 +165,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|temperature|2|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Temperature zone 3",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             convert=lambda x, t: x / 100.0,
             entity_registry_enabled_default=False,
@@ -195,7 +195,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|targetTemperature|0|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Target temperature",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
             convert=lambda x, t: x / 100.0,
@@ -225,7 +225,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|targetTemperature|1|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Target temperature zone 2",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
             convert=lambda x, t: x / 100.0,
@@ -256,7 +256,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             data_tag="state|targetTemperature|2|value_raw",
             device_class=SensorDeviceClass.TEMPERATURE,
             name="Target temperature zone 3",
-            native_unit_of_measurement=TEMP_CELSIUS,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
             convert=lambda x, t: x / 100.0,
@@ -553,7 +553,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             name="Water consumption",
             device_class=SensorDeviceClass.WATER,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=VOLUME_LITERS,
+            native_unit_of_measurement=UnitOfVolume.LITERS,
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=False,
         ),
@@ -571,7 +571,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             name="Energy consumption",
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=False,
         ),
@@ -621,6 +621,32 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             name="Battery",
             device_class=SensorDeviceClass.BATTERY,
             native_unit_of_measurement=PERCENTAGE,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+    ),
+    MieleSensorDefinition(
+        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI],
+        description=MieleSensorDescription(
+            key="coreTemperature",
+            data_tag="state|coreTemperature|0|value_raw",
+            name="Food core temperature",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            state_class=SensorStateClass.MEASUREMENT,
+            convert=lambda x, t: x / 100.0,
+        ),
+    ),
+    MieleSensorDefinition(
+        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI],
+        description=MieleSensorDescription(
+            key="coreTargetTemperature",
+            data_tag="state|coreTargetTemperature|0|value_raw",
+            name="Food core target temperature",
+            icon="mdi:thermometer-check",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            state_class=SensorStateClass.MEASUREMENT,
+            convert=lambda x, t: x / 100.0,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
     ),
@@ -773,8 +799,10 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         if (
             self.coordinator.data[self._ent].get(self.entity_description.data_tag)
             is None
-            or self.coordinator.data[self._ent][self.entity_description.data_tag]
-            == -32766
+        ):
+            return None
+        if (
+            self.coordinator.data[self._ent][self.entity_description.data_tag] == -32766
             or self.coordinator.data[self._ent][self.entity_description.data_tag]
             == -32768
         ):


### PR DESCRIPTION
Add new sensors to ovens according to API 1.0.6 spec. Need to confirm data format before merging.
Fixes #174 