### PR TITLE
Fix error on vacuum platform caused by wrong programID key

### DIFF
--- a/custom_components/miele/vacuum.py
+++ b/custom_components/miele/vacuum.py
@@ -216,14 +216,14 @@ class MieleVacuum(CoordinatorEntity, StateVacuumEntity):
     def fan_speed(self):
         if self.coordinator.data[self._ent]["state|ProgramID|value_raw"] == PROG_AUTO:
             return "normal"
-        elif self.coordinator.data[self._ent]["state|ProgramId|value_raw"] == PROG_SPOT:
+        elif self.coordinator.data[self._ent]["state|ProgramID|value_raw"] == PROG_SPOT:
             return "normal"
         elif (
-            self.coordinator.data[self._ent]["state|ProgramId|value_raw"] == PROG_TURBO
+            self.coordinator.data[self._ent]["state|ProgramID|value_raw"] == PROG_TURBO
         ):
             return "turbo"
         elif (
-            self.coordinator.data[self._ent]["state|ProgramId|value_raw"] == PROG_SILENT
+            self.coordinator.data[self._ent]["state|ProgramID|value_raw"] == PROG_SILENT
         ):
             return "silent"
         return None


### PR DESCRIPTION
Hi I've found a bug when running robot vacuum cleaner with a program that is not the "Auto".
This is the stacktrace:

Traceback (most recent call last):
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/update_coordinator.py", line 168, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/update_coordinator.py", line 316, in _async_refresh
    self.async_update_listeners()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/update_coordinator.py", line 121, in async_update_listeners
    update_callback()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/update_coordinator.py", line 381, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 556, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 596, in _async_write_ha_state
    attr.update(self.state_attributes or {})
  File "/usr/local/python/lib/python3.10/site-packages/homeassistant/components/vacuum/__init__.py", line 227, in state_attributes
    data[ATTR_FAN_SPEED] = self.fan_speed
  File "/config/custom_components/miele/vacuum.py", line 219, in fan_speed
    elif self.coordinator.data[self._ent]["state|ProgramID|value_raw"] == PROG_SPOT:
KeyError: 'state|ProgramId|value_raw'