### PR TITLE
fix elapsed time sensor 

### DIFF
--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -182,6 +182,7 @@ STATE_PROGRAM_PHASE = {
     532: "rinse_out_lint",
     533: "rinses",
     534: "smoothing",
+    536: "not_running",
     538: "slightly_dry",
     539: "safety_cooling",
     # Dishwasher

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -739,6 +739,7 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
             self._attr_icon = self.entity_description.convert_icon(
                 self.coordinator.data[self._ent][self.entity_description.type_key_raw],
             )
+        self._last_elapsed_time_reported = None
         self._last_started_time_reported = None
 
     @property
@@ -747,7 +748,6 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         if self.entity_description.key in [
             "stateRemainingTime",
             "stateStartTime",
-            "stateElapsedTime",
         ]:
             return (
                 self.coordinator.data[self._ent][self.entity_description.data_tag] * 60
@@ -774,6 +774,22 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
             #     (now + timedelta(minutes=mins)).strftime("%H:%M"),
             # )
             return (now + timedelta(minutes=mins)).strftime("%H:%M")
+
+        if self.entity_description.key in [
+            "stateElapsedTime",
+        ]:
+            mins = (
+                self.coordinator.data[self._ent][self.entity_description.data_tag] * 60
+                + self.coordinator.data[self._ent][self.entity_description.data_tag1]
+            )
+            # Don't update sensor if state == program_ended
+            if (
+                self.coordinator.data[self._ent][self.entity_description.status_key_raw]
+                == STATE_STATUS_PROGRAM_ENDED
+            ):
+                return self._last_elapsed_time_reported
+            self._last_elapsed_time_reported = mins
+            return mins
 
         if self.entity_description.key in [
             "stateElapsedTimeAbs",


### PR DESCRIPTION
As is:

- at program end, "elapsed time" sensor may go to 0 because Miele API reports [0,0] (only on some machines, while on others it shows the real elapsed time until the appliance status is program ended)
- at program end, "elapsed time abs" sensors, which is based on the same source data on Miele API, is caching last result at program end, in order to report the correct start time

To be:

Fix elapsed time sensor in order to act in the same way as the abs elapsed time sensor when program ends and correctly report elapsed time until appliance status is "program ended".