### PR TITLE
Add elapsed time sensor on robot vacuum cleaner

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -474,6 +474,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            ROBOT_VACUUM_CLEANER,
         ],
         description=MieleSensorDescription(
             key="stateRemainingTimeAbs",
@@ -544,6 +545,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            ROBOT_VACUUM_CLEANER,
         ],
         description=MieleSensorDescription(
             key="stateElapsedTime",
@@ -568,6 +570,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            ROBOT_VACUUM_CLEANER,
         ],
         description=MieleSensorDescription(
             key="stateElapsedTimeAbs",


### PR DESCRIPTION
Added elapsed time sensor on robot vacuum cleaner.
Added also absolute time sensors for elapsed time and remaining time (non-absolute remaining time sensor was already enabled).