### PR TITLE
Add microwave support

### DIFF
--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -210,6 +210,7 @@ STATE_PROGRAM_PHASE = {
     3073: "heating",  # in common with coffee system
     3074: "process_running",
     3078: "process_finished",
+    3084: "energy_save",
     # Coffee system
     4352: "not_running",
     4353: "espresso",

--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -211,6 +211,11 @@ STATE_PROGRAM_PHASE = {
     3074: "process_running",
     3078: "process_finished",
     3084: "energy_save",
+    # Microwave
+    3329: "heating",
+    3330: "process_running",
+    3334: "process_finished",
+    3340: "energy_save",
     # Coffee system
     4352: "not_running",
     4353: "espresso",
@@ -348,6 +353,7 @@ OVEN_PROGRAM_ID = {
     11: "economy_grill",
     13: "fan_plus",
     14: "intensive_bake",
+    19: "microwave",
     24: "conventional_heat",
     25: "top_heat",
     29: "fan_grill",
@@ -547,6 +553,7 @@ STATE_PROGRAM_ID = {
     TUMBLE_DRYER: TUMBLE_DRYER_PROGRAM_ID,
     DISHWASHER: DISHWASHER_PROGRAM_ID,
     OVEN: OVEN_PROGRAM_ID,
+    OVEN_MICROWAVE: OVEN_PROGRAM_ID,
     WASHER_DRYER: WASHING_MACHINE_PROGRAM_ID,
     ROBOT_VACUUM_CLEANER: ROBOT_VACUUM_CLEANER_PROGRAM_ID,
     COFFEE_SYSTEM: COFFEE_SYSTEM_PROGRAM_ID,

--- a/custom_components/miele/strings.json
+++ b/custom_components/miele/strings.json
@@ -352,6 +352,7 @@
                     "final_rinse": "Final rinse",
                     "process_running": "Process running",
                     "process_finished": "Process finished",
+                    "energy_save": "Energy save",
                     "espresso": "Espresso coffee",
                     "heating": "Heating",
                     "hot_milk": "Hot milk",

--- a/custom_components/miele/strings.json
+++ b/custom_components/miele/strings.json
@@ -261,6 +261,7 @@
                     "economy_grill": "Economy grill",
                     "fan_plus": "Fan Plus",
                     "intensive_bake": "Intensive bake",
+                    "microwave": "Microwave",
                     "conventional_heat": "Conventional heat",
                     "top_heat": "Top heat",
                     "fan_grill": "Fan grill",

--- a/custom_components/miele/translations/de.json
+++ b/custom_components/miele/translations/de.json
@@ -261,6 +261,7 @@
                     "economy_grill": "Grill klein",
                     "fan_plus": "Heißluft plus",
                     "intensive_bake": "Intensivbacken",
+                    "microwave": "Mikrowelle",
                     "conventional_heat": "Ober-/Unterhitze",
                     "top_heat": "Oberhitze",
                     "fan_grill": "Umluftgrill",

--- a/custom_components/miele/translations/de.json
+++ b/custom_components/miele/translations/de.json
@@ -352,6 +352,7 @@
                     "final_rinse": "Klarspülen",
                     "process_running": "Prozess läuft",
                     "process_finished": "Prozess beendet",
+                    "energy_save": "Energie sparen",
                     "espresso": "Espresso",
                     "heating": "Heizen",
                     "hot_milk": "Heiße Milch",

--- a/custom_components/miele/translations/en.json
+++ b/custom_components/miele/translations/en.json
@@ -352,6 +352,7 @@
                     "final_rinse": "Final rinse",
                     "process_running": "Process running",
                     "process_finished": "Process finished",
+                    "energy_save": "Energy save",
                     "espresso": "Espresso coffee",
                     "heating": "Heating",
                     "hot_milk": "Hot milk",

--- a/custom_components/miele/translations/en.json
+++ b/custom_components/miele/translations/en.json
@@ -261,6 +261,7 @@
                     "economy_grill": "Economy grill",
                     "fan_plus": "Fan Plus",
                     "intensive_bake": "Intensive bake",
+                    "microwave": "Microwave",
                     "conventional_heat": "Conventional heat",
                     "top_heat": "Top heat",
                     "fan_grill": "Fan grill",

--- a/custom_components/miele/translations/fr.json
+++ b/custom_components/miele/translations/fr.json
@@ -210,6 +210,7 @@
                     "process_finished": "Cycle terminé",
                     "espresso": "Espresso",
                     "heating": "Chauffage",
+                    "energy_save": "Économiser de l'énergie",
                     "hot_milk": "Lait chaud",
                     "milk_foam": "Mousse de lait",
                     "dispensing": "Distribution",

--- a/custom_components/miele/translations/fr.json
+++ b/custom_components/miele/translations/fr.json
@@ -118,6 +118,7 @@
                     "economy_grill": "Grill éco",
                     "fan_plus": "Air Plus",
                     "intensive_bake": "Cuisson intense",
+                    "microwave": "Micro-ondes",
                     "conventional_heat": "Cuisson standard",
                     "top_heat": "Chaleur par le haut",
                     "fan_grill": "Grill ventilé",

--- a/custom_components/miele/translations/hu.json
+++ b/custom_components/miele/translations/hu.json
@@ -263,6 +263,7 @@
                   "economy_grill": "Takarékos grill",
                   "fan_plus": "Venti Plusz",
                   "intensive_bake": "Intenzív sütés",
+                  "microwave": "Mikrohullám",
                   "conventional_heat": "Hagyományos fűtés",
                   "top_heat": "Felső",
                   "fan_grill": "Hőlégkeverés",

--- a/custom_components/miele/translations/hu.json
+++ b/custom_components/miele/translations/hu.json
@@ -354,6 +354,7 @@
                   "final_rinse": "Végső öblítés",
                   "process_running": "Folyamatban",
                   "process_finished": "Elkészült",
+                  "energy_save": "Energy save",
                   "espresso": "Espresso kávé",
                   "heating": "Melegítés",
                   "hot_milk": "Forró tej",

--- a/custom_components/miele/translations/it.json
+++ b/custom_components/miele/translations/it.json
@@ -352,6 +352,7 @@
                     "final_rinse": "Risciacquo con brillantante",
                     "process_running": "Procedimento in corso",
                     "process_finished": "Procedimento terminato",
+                    "energy_save": "Energy save",
                     "espresso": "Caffè espresso",
                     "heating": "Riscaldamento",
                     "hot_milk": "Latte caldo",

--- a/custom_components/miele/translations/it.json
+++ b/custom_components/miele/translations/it.json
@@ -261,6 +261,7 @@
                     "economy_grill": "Grill piccolo",
                     "fan_plus": "Thermovent plus",
                     "intensive_bake": "Cottura intensa",
+                    "microwave": "Microonde",
                     "conventional_heat": "Calore superiore/inferiore",
                     "top_heat": "Calore superiore",
                     "fan_grill": "Grill ventilato",

--- a/custom_components/miele/translations/nb.json
+++ b/custom_components/miele/translations/nb.json
@@ -118,6 +118,7 @@
                     "economy_grill": "Økonomi-grill",
                     "fan_plus": "Varmluft Plus",
                     "intensive_bake": "Intensivbaking",
+                    "microwave": "Microwave",
                     "conventional_heat": "Konventionell varme",
                     "top_heat": "Overvarme",
                     "fan_grill": "Varmluftsgrill",

--- a/custom_components/miele/translations/nb.json
+++ b/custom_components/miele/translations/nb.json
@@ -208,6 +208,7 @@
                     "final_rinse": "Sluttskylling",
                     "process_running": "Process running",
                     "process_finished": "Process finished",
+                    "energy_save": "Energy save",
                     "espresso": "Espresso coffee",
                     "heating": "Heating",
                     "hot_milk": "Hot milk",

--- a/custom_components/miele/translations/nl.json
+++ b/custom_components/miele/translations/nl.json
@@ -353,6 +353,7 @@
                     "final_rinse": "Afspoelen",
                     "process_running": "Proces loopt",
                     "process_finished": "Proces voltooid",
+                    "energy_save": "Energie besparen",
                     "espresso": "Espresso",
                     "heating": "Verwarmen",
                     "hot_milk": "Hete melk",

--- a/custom_components/miele/translations/nl.json
+++ b/custom_components/miele/translations/nl.json
@@ -262,6 +262,7 @@
                     "economy_grill": "Economische grill",
                     "fan_plus": "Hete lucht Plus",
                     "intensive_bake": "Intensief bakken",
+                    "microwave": "Microgolf",
                     "conventional_heat": "Boven/onder warmte",
                     "top_heat": "Boven warmte",
                     "fan_grill": "Hete lucht grill",

--- a/custom_components/miele/translations/sv.json
+++ b/custom_components/miele/translations/sv.json
@@ -353,7 +353,7 @@
                     "final_rinse": "Slutsköljning",
                     "process_running": "Process körs",
                     "process_finished": "Process klar",
-                    "energy_save": "Energy save",
+                    "energy_save": "Energisparläge",
                     "espresso": "Espresso kaffe",
                     "heating": "Värmer",
                     "hot_milk": "Varm mjölk",

--- a/custom_components/miele/translations/sv.json
+++ b/custom_components/miele/translations/sv.json
@@ -261,6 +261,7 @@
                     "economy_grill": "Ekonomi grill",
                     "fan_plus": "Varmluft Plus",
                     "intensive_bake": "Intensivbakning",
+                    "microwave": "Mikrovågsfunktion",
                     "conventional_heat": "Konventionell värme",
                     "top_heat": "Övervärme",
                     "fan_grill": "Varmluftsgrill",

--- a/custom_components/miele/translations/sv.json
+++ b/custom_components/miele/translations/sv.json
@@ -352,6 +352,7 @@
                     "final_rinse": "Slutsköljning",
                     "process_running": "Process körs",
                     "process_finished": "Process klar",
+                    "energy_save": "Energy save",
                     "espresso": "Espresso kaffe",
                     "heating": "Värmer",
                     "hot_milk": "Varm mjölk",


### PR DESCRIPTION
This adds support for microwaves. Microwave mappings are in the same set as ovens, so I combined them. I can add more program phases, but these are the ones I've used so far.

_I may start a war because of the Dutch translation, but oh well I was first and there is no way to accommodate everyone._ :sweat_smile: