### PR TITLE
Fixes on absolute time sensors

### DIFF
--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -942,11 +942,11 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         # check for previous value and return it if differning of +/-1 min
         if self.entity_description.key in self._last_abs_time:
             previous_value = self._last_abs_time[self.entity_description.key]
-            prev_minute = (val - timedelta(minutes=1)).strftime("%H:%M")
-            next_minute = (val + timedelta(minutes=1)).strftime("%H:%M")
-            if formatted == prev_minute or formatted == next_minute:
-                return previous_value
-        self._last_abs_time[self.entity_description.key] = formatted
+            prev_minute = previous_value - timedelta(minutes=1)
+            next_minute = previous_value + timedelta(minutes=1)
+            if val == prev_minute or val == next_minute:
+                return previous_value.strftime("%H:%M")
+        self._last_abs_time[self.entity_description.key] = val
         return formatted
 
     @property

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -922,7 +922,7 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         return mins
 
     def _get_absolute_time(self, sub=False):
-        now = dt_util.now()
+        now = dt_util.now().replace(second=0, microsecond=0)
         mins = self._get_minutes()
         if mins == 0:
             return None
@@ -942,9 +942,9 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         # check for previous value and return it if differning of +/-1 min
         if self.entity_description.key in self._last_abs_time:
             previous_value = self._last_abs_time[self.entity_description.key]
-            prev_minute = previous_value - timedelta(minutes=1)
-            next_minute = previous_value + timedelta(minutes=1)
-            if val == prev_minute or val == next_minute:
+            prev_minute = previous_value - timedelta(seconds=120)
+            next_minute = previous_value + timedelta(seconds=120)
+            if prev_minute <= val <= next_minute:
                 return previous_value.strftime("%H:%M")
         self._last_abs_time[self.entity_description.key] = val
         return formatted


### PR DESCRIPTION
Hi @astrandb,
I have addressed the problem related to the issue https://github.com/astrandb/miele/issues/288, by forcing none value on started time abs and elapsed time when appliance is off.

I also refactored the code related to time sensor to be more readable and I have fixed two other issues:

- sometimes absolute time sensors keep updating their value with a string that is +/-1 minute because it is computed starting from now +/- the relative time in minutes obtained from API --> changes within 120 seconds of absolute time sensors are not reported (loosing 120s of precision, I think it's a good compromise) by caching previous value
- finish time sensor did not take into account time until delayed start --> I have added the time to start the appliance in order to have correct finish time

I'm testing this branch in these days, so I will write here when this branch is safe to be merged.

Thanks
Andrea