### PR TITLE
Use localized name of appliance device type if available

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -261,7 +261,7 @@ async def get_coordinator(
             async with async_timeout.timeout(API_READ_TIMEOUT):
                 res = await miele_api.request(
                     "GET",
-                    "/devices",
+                    f"/devices?language={hass.config.language}",
                     agent_suffix=f"Miele for Home Assistant/{VERSION}",
                 )
             if res.status == 401:


### PR DESCRIPTION
Use Miele's built-in localization for createing device names e.g. Refridgerator = Kühlschrank in German. A handful of languages are supported by Miele API. English is used as fallback for unsupported languages.
Currently Miele supports: da, de, en, es, fr, it, nb, nl.