### PR TITLE
Basic support for devtype 73 = steam oven

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -62,6 +62,7 @@ from .devcap import (  # noqa: F401
     TEST_DATA_24,
     TEST_DATA_27,
     TEST_DATA_27_OFF,
+    TEST_DATA_73,
     TEST_DATA_74,
 )
 from .services import async_setup_services
@@ -210,6 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # data["1223024"] = TEST_DATA_24
         # data["122A027"] = TEST_DATA_27
         # data["122B027"] = TEST_DATA_27_OFF
+        # data["1223073"] = TEST_DATA_73
         # data["1223074"] = TEST_DATA_74
         flat_result: dict = {}
         try:
@@ -293,6 +295,7 @@ async def get_coordinator(
         # result["1223024"] = TEST_DATA_24
         # result["122A027"] = TEST_DATA_27
         # result["122B027"] = TEST_DATA_27_OFF
+        # result["1223073"] = TEST_DATA_73
         # result["1223074"] = TEST_DATA_74
 
         try:

--- a/custom_components/miele/binary_sensor.py
+++ b/custom_components/miele/binary_sensor.py
@@ -42,6 +42,7 @@ from .const import (
     STEAM_OVEN,
     STEAM_OVEN_COMBI,
     STEAM_OVEN_MICRO,
+    STEAM_OVEN_MK2,
     TUMBLE_DRYER,
     TUMBLE_DRYER_SEMI_PROFESSIONAL,
     WASHER_DRYER,
@@ -93,6 +94,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             WINE_STORAGE_CONDITIONING_UNIT,
             STEAM_OVEN_MICRO,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleBinarySensorDescription(
             key="door",
@@ -126,6 +128,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleBinarySensorDescription(
             key="info",
@@ -162,6 +165,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
             HOB_INDUCT_EXTR,
         ],
         description=MieleBinarySensorDescription(
@@ -197,6 +201,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
             HOB_INDUCT_EXTR,
         ],
         description=MieleBinarySensorDescription(
@@ -231,6 +236,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
             HOB_INDUCT_EXTR,
         ],
         description=MieleBinarySensorDescription(
@@ -266,6 +272,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
             HOB_INDUCT_EXTR,
         ],
         description=MieleBinarySensorDescription(

--- a/custom_components/miele/button.py
+++ b/custom_components/miele/button.py
@@ -37,6 +37,7 @@ from .const import (
     STEAM_OVEN,
     STEAM_OVEN_COMBI,
     STEAM_OVEN_MICRO,
+    STEAM_OVEN_MK2,
     TUMBLE_DRYER,
     TUMBLE_DRYER_SEMI_PROFESSIONAL,
     WASHER_DRYER,
@@ -76,6 +77,7 @@ BUTTON_TYPES: Final[tuple[MieleButtonDefinition, ...]] = (
             WASHER_DRYER,
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
+            STEAM_OVEN_MK2,
             DIALOG_OVEN,
         ],
         description=MieleButtonDescription(
@@ -98,6 +100,7 @@ BUTTON_TYPES: Final[tuple[MieleButtonDefinition, ...]] = (
             WASHER_DRYER,
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
+            STEAM_OVEN_MK2,
             DIALOG_OVEN,
         ],
         description=MieleButtonDescription(

--- a/custom_components/miele/const.py
+++ b/custom_components/miele/const.py
@@ -43,6 +43,7 @@ WINE_STORAGE_CONDITIONING_UNIT = 34
 STEAM_OVEN_MICRO = 45
 DIALOG_OVEN = 67
 WINE_CABINET_FREEZER = 68
+STEAM_OVEN_MK2 = 73
 HOB_INDUCT_EXTR = 74
 
 APPLIANCE_TYPES = {
@@ -76,6 +77,7 @@ APPLIANCE_TYPES = {
     STEAM_OVEN_MICRO: "steam_oven_micro",
     DIALOG_OVEN: "dialog_oven",
     WINE_CABINET_FREEZER: "wine_cabinet_freezer",
+    STEAM_OVEN_MK2: "steam_oven",
     HOB_INDUCT_EXTR: "hob_induct_extr",
 }
 

--- a/custom_components/miele/devcap.py
+++ b/custom_components/miele/devcap.py
@@ -1137,6 +1137,99 @@ TEST_DATA_27_OFF = {
     },
 }
 
+TEST_DATA_73 = {
+    "ident": {
+        "type": {
+            "key_localized": "Device type",
+            "value_raw": 73,
+            "value_localized": "",
+        },
+        "deviceName": "",
+        "protocolVersion": 203,
+        "deviceIdentLabel": {
+            "fabNumber": "**REDACTED**",
+            "fabIndex": "00",
+            "techType": "DGC7450",
+            "matNumber": "11785200",
+            "swids": ["000"],
+        },
+        "xkmIdentLabel": {
+            "techType": "EK057",
+            "releaseVersion": "08.23",
+        },
+    },
+    "state": {
+        "ProgramID": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program name",
+        },
+        "status": {
+            "value_raw": 2,
+            "value_localized": "On",
+            "key_localized": "status",
+        },
+        "programType": {
+            "value_raw": 1,
+            "value_localized": "Own programme",
+            "key_localized": "Program type",
+        },
+        "programPhase": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program phase",
+        },
+        "remainingTime": [0, 0],
+        "startTime": [0, 0],
+        "targetTemperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "coreTargetTemperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "temperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "coreTemperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "signalInfo": False,
+        "signalFailure": False,
+        "signalDoor": False,
+        "remoteEnable": {
+            "fullRemoteControl": True,
+            "smartGrid": False,
+            "mobileStart": True,
+        },
+        "ambientLight": None,
+        "light": 2,
+        "elapsedTime": [0, 0],
+        "spinningSpeed": {
+            "unit": "rpm",
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Spin speed",
+        },
+        "dryingStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Drying level",
+        },
+        "ventilationStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Fan level",
+        },
+        "plateStep": {},
+        "ecoFeedback": None,
+        "batteryLevel": None,
+    },
+}
+
 TEST_DATA_74 = {
     "ident": {
         "type": {

--- a/custom_components/miele/light.py
+++ b/custom_components/miele/light.py
@@ -35,6 +35,7 @@ from .const import (
     STEAM_OVEN,
     STEAM_OVEN_COMBI,
     STEAM_OVEN_MICRO,
+    STEAM_OVEN_MK2,
     WINE_CABINET,
     WINE_CABINET_FREEZER,
     WINE_CONDITIONING_UNIT,
@@ -78,6 +79,7 @@ LIGHT_TYPES: Final[tuple[MieleLightDefinition, ...]] = (
             WINE_STORAGE_CONDITIONING_UNIT,
             STEAM_OVEN_MICRO,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleLightDescription(
             key="light",

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -1,4 +1,6 @@
 """Platform for Miele sensor integration."""
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -68,6 +70,7 @@ from .const import (
     STEAM_OVEN,
     STEAM_OVEN_COMBI,
     STEAM_OVEN_MICRO,
+    STEAM_OVEN_MK2,
     TUMBLE_DRYER,
     TUMBLE_DRYER_SEMI_PROFESSIONAL,
     WASHER_DRYER,
@@ -125,6 +128,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="temperature",
@@ -153,6 +157,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="temperature2",
@@ -181,6 +186,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="temperature3",
@@ -211,6 +217,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="targetTemperature",
@@ -240,6 +247,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="targetTemperature2",
@@ -270,6 +278,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="targetTemperature3",
@@ -309,6 +318,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             WINE_CABINET_FREEZER,
+            STEAM_OVEN_MK2,
             HOB_INDUCT_EXTR,
         ],
         description=MieleSensorDescription(
@@ -344,6 +354,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateProgramId",
@@ -372,6 +383,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             COFFEE_SYSTEM,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateProgramType",
@@ -400,6 +412,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateProgramPhase",
@@ -457,6 +470,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateRemainingTime",
@@ -483,6 +497,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             ROBOT_VACUUM_CLEANER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateRemainingTimeAbs",
@@ -510,6 +525,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateStartTime",
@@ -535,6 +551,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateStartTimeAbs",
@@ -559,6 +576,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             ROBOT_VACUUM_CLEANER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateElapsedTime",
@@ -584,6 +602,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
             ROBOT_VACUUM_CLEANER,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSensorDescription(
             key="stateElapsedTimeAbs",
@@ -680,7 +699,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
         ),
     ),
     MieleSensorDefinition(
-        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI],
+        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI, STEAM_OVEN_MK2],
         description=MieleSensorDescription(
             key="coreTemperature",
             data_tag="state|coreTemperature|0|value_raw",
@@ -692,7 +711,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
         ),
     ),
     MieleSensorDefinition(
-        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI],
+        types=[OVEN, OVEN_MICROWAVE, STEAM_OVEN_COMBI, STEAM_OVEN_MK2],
         description=MieleSensorDescription(
             key="coreTargetTemperature",
             data_tag="state|coreTargetTemperature|0|value_raw",

--- a/custom_components/miele/switch.py
+++ b/custom_components/miele/switch.py
@@ -43,6 +43,7 @@ from .const import (
     STEAM_OVEN,
     STEAM_OVEN_COMBI,
     STEAM_OVEN_MICRO,
+    STEAM_OVEN_MK2,
     TUMBLE_DRYER,
     TUMBLE_DRYER_SEMI_PROFESSIONAL,
     WASHER_DRYER,
@@ -114,6 +115,7 @@ SWITCH_TYPES: Final[tuple[MieleSwitchDefinition, ...]] = (
             STEAM_OVEN_COMBI,
             STEAM_OVEN_MICRO,
             DIALOG_OVEN,
+            STEAM_OVEN_MK2,
         ],
         description=MieleSwitchDescription(
             key="poweronoff",


### PR DESCRIPTION
A new steam oven model reports device type 73 in the API. This PR enables basic support until Miele publishes an updated compatibility sheet.

Fixes #376 