### PR TITLE
Change from VacuumEntityDescription to StateVacuumEntityDescription to support HA2024.02

### DIFF
--- a/custom_components/miele/vacuum.py
+++ b/custom_components/miele/vacuum.py
@@ -16,7 +16,7 @@ from homeassistant.components.vacuum import (
     STATE_PAUSED,
     STATE_RETURNING,
     StateVacuumEntity,
-    VacuumEntityDescription,
+    StateVacuumEntityDescription,
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant
@@ -69,7 +69,7 @@ SUPPORTED_FEATURES = (
 
 
 @dataclass
-class MieleVacuumDescription(VacuumEntityDescription):
+class MieleVacuumDescription(StateVacuumEntityDescription):
     """Class describing Miele vacuum entities."""
 
     data_tag: str | None = None


### PR DESCRIPTION
VacuumEntityDescription was deprecated some months before and gets deleted with HA2024.02.

I have changed the code to StateVacuumEntityDescription.

Link to HA --> Add of [StateVacuumEntityDescription](https://github.com/home-assistant/core/pull/53521) 
Link to HA --> Deletion of [VacuumEntityDescription](https://github.com/home-assistant/core/pull/108189)

Would be great if you could check it and release a new version soon. HA release 2024.02 is planned for Feb-07

Thx for the great component

