### PR TITLE
add 6 plates for "KM X" old zigbee hob

### DIFF
--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -71,6 +71,7 @@ PLATE_COUNT = {
     "KM7897": 6,
     "KMDA7633": 5,
     "KMDA7634": 5,
+    "KMX": 6,
 }
 
 


### PR DESCRIPTION
I have an older (around 2015) zigbeee connected hob with 6 plates which identifies itself as "KM X".
```
  "data": {
    "info": {
      "manufacturer": "Miele",
      "model": "KM X"
    },
    "data": {
      "ident|type|key_localized": "Device type",
      "ident|type|value_raw": 27,
      "ident|type|value_localized": "Hob",
      "ident|deviceName": "",
      "ident|protocolVersion": 1,
      "ident|deviceIdentLabel|fabNumber": "**REDACTED**",
      "ident|deviceIdentLabel|fabIndex": "00",
      "ident|deviceIdentLabel|techType": "KM X",
      "ident|deviceIdentLabel|matNumber": "00000000",
      "ident|deviceIdentLabel|swids|0": "12869",
      "ident|deviceIdentLabel|swids|1": "0",
      "ident|xkmIdentLabel|techType": "",
      "ident|xkmIdentLabel|releaseVersion": "",
      "state|ProgramID|value_raw": 0,
      "state|ProgramID|value_localized": "",
      "state|ProgramID|key_localized": "Program name",
      "state|status|value_raw": 1,
      "state|status|value_localized": "Off",
      "state|status|key_localized": "status",
      "state|programType|value_raw": 0,
      "state|programType|value_localized": "",
      "state|programType|key_localized": "Program type",
      "state|programPhase|value_raw": 0,
      "state|programPhase|value_localized": "",
      "state|programPhase|key_localized": "Program phase",
      "state|remainingTime|0": 0,
      "state|remainingTime|1": 0,
      "state|startTime|0": 0,
      "state|startTime|1": 0,
      "state|targetTemperature|0|value_raw": -32768,
      "state|targetTemperature|0|value_localized": null,
      "state|targetTemperature|0|unit": "Celsius",
      "state|targetTemperature|1|value_raw": -32768,
      "state|targetTemperature|1|value_localized": null,
      "state|targetTemperature|1|unit": "Celsius",
      "state|targetTemperature|2|value_raw": -32768,
      "state|targetTemperature|2|value_localized": null,
      "state|targetTemperature|2|unit": "Celsius",
      "state|coreTargetTemperature|0|value_raw": -32768,
      "state|coreTargetTemperature|0|value_localized": null,
      "state|coreTargetTemperature|0|unit": "Celsius",
      "state|temperature": {},
      "state|coreTemperature|0|value_raw": -32768,
      "state|coreTemperature|0|value_localized": null,
      "state|coreTemperature|0|unit": "Celsius",
      "state|signalInfo": false,
      "state|signalFailure": false,
      "state|signalDoor": false,
      "state|remoteEnable|fullRemoteControl": false,
      "state|remoteEnable|smartGrid": false,
      "state|remoteEnable|mobileStart": false,
      "state|ambientLight": null,
      "state|light": null,
      "state|elapsedTime": {},
      "state|spinningSpeed|unit": "rpm",
      "state|spinningSpeed|value_raw": null,
      "state|spinningSpeed|value_localized": null,
      "state|spinningSpeed|key_localized": "Spin speed",
      "state|dryingStep|value_raw": null,
      "state|dryingStep|value_localized": "",
      "state|dryingStep|key_localized": "Drying level",
      "state|ventilationStep|value_raw": null,
      "state|ventilationStep|value_localized": "",
      "state|ventilationStep|key_localized": "Fan level",
      "state|plateStep": {},
      "state|ecoFeedback": null,
      "state|batteryLevel": null
    },
    "actions": {
      "processAction": [],
      "light": [],
      "ambientLight": [],
      "startTime": [],
      "ventilationStep": [],
      "programId": [],
      "targetTemperature": [],
      "deviceName": true,
      "powerOn": true,
      "powerOff": false,
      "colors": [],
      "modes": [],
      "runOnTime": []
    },
    "programs": [],
    "id_log": [],
    "local_mappings": {}
  }
```