### PR TITLE
Use common entity class

### DIFF
--- a/custom_components/miele/binary_sensor.py
+++ b/custom_components/miele/binary_sensor.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
     DataUpdateCoordinator,
 )
 
@@ -53,6 +52,7 @@ from .const import (
     WINE_CONDITIONING_UNIT,
     WINE_STORAGE_CONDITIONING_UNIT,
 )
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -316,7 +316,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class MieleBinarySensor(MieleEntity, BinarySensorEntity):
     """Representation of a Binary Sensor."""
 
     entity_description: MieleBinarySensorDescription
@@ -329,25 +329,8 @@ class MieleBinarySensor(CoordinatorEntity, BinarySensorEntity):
         description: MieleBinarySensorDescription,
     ):
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._idx = idx
-        self._ent = ent
-        self.entity_description = description
+        super().__init__(coordinator, idx, ent, description)
         _LOGGER.debug("init sensor %s", ent)
-        appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
-        if appl_type == "":
-            appl_type = self.coordinator.data[self._ent][
-                "ident|deviceIdentLabel|techType"
-            ]
-        self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-        )
 
     @property
     def is_on(self):

--- a/custom_components/miele/button.py
+++ b/custom_components/miele/button.py
@@ -13,10 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import get_coordinator
 from .const import (
@@ -44,6 +41,7 @@ from .const import (
     WASHER_DRYER,
     WASHING_MACHINE,
 )
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,7 +143,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleButton(CoordinatorEntity, ButtonEntity):
+class MieleButton(MieleEntity, ButtonEntity):
     """Representation of a Button."""
 
     entity_description: MieleButtonDescription
@@ -160,28 +158,10 @@ class MieleButton(CoordinatorEntity, ButtonEntity):
         entry: ConfigType,
     ):
         """Initialize the button."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, idx, ent, description)
         self._api = hass.data[DOMAIN][entry.entry_id][API]
         self._api_data = hass.data[DOMAIN][entry.entry_id]
-
-        self._idx = idx
-        self._ent = ent
-        self.entity_description = description
         _LOGGER.debug("init button %s", ent)
-        appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
-        if appl_type == "":
-            appl_type = self.coordinator.data[self._ent][
-                "ident|deviceIdentLabel|techType"
-            ]
-        self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-        )
 
     def _action_available(self, action) -> bool:
         """Check if action is available according to API."""

--- a/custom_components/miele/climate.py
+++ b/custom_components/miele/climate.py
@@ -18,13 +18,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import get_coordinator
 from .const import ACTIONS, API, DOMAIN, MANUFACTURER, TARGET_TEMPERATURE
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,7 +144,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleClimate(CoordinatorEntity, ClimateEntity):
+class MieleClimate(MieleEntity, ClimateEntity):
     """Representation of a climate entity."""
 
     entity_description: MieleClimateDescription
@@ -161,23 +159,16 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
         entry,
     ):
         """Initialize the climate entity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, idx, ent, description)
         self._eid = hass.data[DOMAIN][entry.entry_id]
         self._api = self._eid[API]
 
-        self._idx = idx
-        self._ent = ent
         self._ed = description
         _LOGGER.debug("init climate %s", ent)
         # _LOGGER.debug(
         #   "Type: %s, Zone: %s",
         #   self.coordinator.data[self._ent]["ident|type|value_raw"], self._ed.zone,
         # )
-        appl_type = self.coordinator.data[self._ent][self._ed.type_key]
-        if appl_type == "":
-            appl_type = self.coordinator.data[self._ent][
-                "ident|deviceIdentLabel|techType"
-            ]
 
         if (
             self.coordinator.data[self._ent]["ident|type|value_raw"] == 21
@@ -202,7 +193,6 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
         else:
             name = self._ed.name
         self._attr_translation_key = name
-        self._attr_has_entity_name = True
 
         zone = "" if self._ed.zone == 0 else f"{self._ed.zone}-"
         self._attr_unique_id = f"{self._ed.key}-{zone}{self._ent}"
@@ -227,13 +217,6 @@ class MieleClimate(CoordinatorEntity, ClimateEntity):
         self._attr_hvac_modes = self._ed.hvac_modes
         self._attr_hvac_mode = HVACMode.COOL
         self._attr_supported_features = self._ed.supported_features
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-        )
 
     @property
     def current_temperature(self):

--- a/custom_components/miele/climate.py
+++ b/custom_components/miele/climate.py
@@ -232,6 +232,7 @@ class MieleClimate(MieleEntity, ClimateEntity):
         self._attr_translation_key = name
 
         zone = "" if self._ed.zone == 0 else f"{self._ed.zone}-"
+        # deviates from MieleEntity
         self._attr_unique_id = f"{self._ed.key}-{zone}{self._ent}"
         self._attr_temperature_unit = self._ed.temperature_unit
         self._attr_precision = self._ed.precision

--- a/custom_components/miele/entity.py
+++ b/custom_components/miele/entity.py
@@ -1,0 +1,42 @@
+"""Entities for the Miele integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN, MANUFACTURER
+
+
+class MieleEntity(CoordinatorEntity):
+    """Base class for Miele entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        idx,
+        ent,
+        description: EntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._idx = idx
+        self._ent = ent
+        self.entity_description = description
+        appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
+        if appl_type == "":
+            appl_type = self.coordinator.data[self._ent][
+                "ident|deviceIdentLabel|techType"
+            ]
+        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._ent)},
+            serial_number=self._ent,
+            name=appl_type,
+            manufacturer=MANUFACTURER,
+            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
+        )

--- a/custom_components/miele/entity.py
+++ b/custom_components/miele/entity.py
@@ -39,4 +39,8 @@ class MieleEntity(CoordinatorEntity):
             name=appl_type,
             manufacturer=MANUFACTURER,
             model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
+            hw_version=self.coordinator.data[self._ent]["ident|xkmIdentLabel|techType"],
+            sw_version=self.coordinator.data[self._ent][
+                "ident|xkmIdentLabel|releaseVersion"
+            ],
         )

--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -174,7 +174,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleNumber(CoordinatorEntity, NumberEntity):
+class MieleNumber(MieleEntity, NumberEntity):
     """Representation of a Number."""
 
     entity_description: MieleNumberDescription
@@ -189,28 +189,13 @@ class MieleNumber(CoordinatorEntity, NumberEntity):
         entry: ConfigType,
     ):
         """Initialize the number."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, idx, ent, description)
         self._api = hass.data[DOMAIN][entry.entry_id][API]
-
-        self._idx = idx
-        self._ent = ent
-        self.entity_description = description
         self._ed = description
         _LOGGER.debug("Init number %s", ent)
-        appl_type = self.coordinator.data[self._ent][self._ed.type_key]
-        tech_type = self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"]
-        if appl_type == "":
-            appl_type = tech_type
-        self._attr_has_entity_name = True
+        # deviates from MieleEntity
         self._attr_unique_id = f"{self._ed.key}-{self._ed.zone}{self._ent}"
         self._attr_mode = NumberMode.SLIDER
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-        )
 
     @property
     def native_value(self):

--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -17,10 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import get_coordinator
 from .const import (
@@ -31,6 +28,7 @@ from .const import (
     HOB_INDUCTION,
     MANUFACTURER,
 )
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -26,10 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from . import get_coordinator
@@ -49,7 +46,6 @@ from .const import (
     HOB_INDUCT_EXTR,
     HOB_INDUCTION,
     HOOD,
-    MANUFACTURER,
     MICROWAVE,
     OVEN,
     OVEN_MICROWAVE,
@@ -80,6 +76,7 @@ from .const import (
     WINE_CONDITIONING_UNIT,
     WINE_STORAGE_CONDITIONING_UNIT,
 )
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -752,7 +749,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleSensor(CoordinatorEntity, SensorEntity):
+class MieleSensor(MieleEntity, SensorEntity):
     """Representation of a Sensor."""
 
     entity_description: MieleSensorDescription
@@ -765,18 +762,14 @@ class MieleSensor(CoordinatorEntity, SensorEntity):
         description: MieleSensorDescription,
     ):
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._idx = idx
-        self._ent = ent
-        self.entity_description = description
+        super().__init__(coordinator, idx, ent, description)
         _LOGGER.debug("init sensor %s", ent)
         appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
         if appl_type == "":
             appl_type = self.coordinator.data[self._ent][
                 "ident|deviceIdentLabel|techType"
             ]
-        self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
+        # deviates from MieleEntity
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ent)},
             serial_number=self._ent,

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -46,7 +46,6 @@ from .const import (
     HOB_INDUCT_EXTR,
     HOB_INDUCTION,
     HOOD,
-    MANUFACTURER,
     MICROWAVE,
     OVEN,
     OVEN_MICROWAVE,
@@ -765,23 +764,6 @@ class MieleSensor(MieleEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator, idx, ent, description)
         _LOGGER.debug("init sensor %s", ent)
-        appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
-        if appl_type == "":
-            appl_type = self.coordinator.data[self._ent][
-                "ident|deviceIdentLabel|techType"
-            ]
-        # deviates from MieleEntity
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-            hw_version=self.coordinator.data[self._ent]["ident|xkmIdentLabel|techType"],
-            sw_version=self.coordinator.data[self._ent][
-                "ident|xkmIdentLabel|releaseVersion"
-            ],
-        )
         if self.entity_description.convert_icon is not None:
             self._attr_icon = self.entity_description.convert_icon(
                 self.coordinator.data[self._ent][self.entity_description.type_key_raw],

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -46,6 +46,7 @@ from .const import (
     HOB_INDUCT_EXTR,
     HOB_INDUCTION,
     HOOD,
+    MANUFACTURER,
     MICROWAVE,
     OVEN,
     OVEN_MICROWAVE,

--- a/custom_components/miele/switch.py
+++ b/custom_components/miele/switch.py
@@ -13,10 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import get_coordinator
 from .const import (
@@ -35,7 +32,6 @@ from .const import (
     FRIDGE,
     FRIDGE_FREEZER,
     HOOD,
-    MANUFACTURER,
     MICROWAVE,
     OVEN,
     OVEN_MICROWAVE,
@@ -52,6 +48,7 @@ from .const import (
     WASHING_MACHINE,
     WINE_CABINET_FREEZER,
 )
+from .entity import MieleEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -165,7 +162,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MieleSwitch(CoordinatorEntity, SwitchEntity):
+class MieleSwitch(MieleEntity, SwitchEntity):
     """Representation of a Switch."""
 
     entity_description: MieleSwitchDescription
@@ -180,28 +177,10 @@ class MieleSwitch(CoordinatorEntity, SwitchEntity):
         entry: ConfigType,
     ):
         """Initialize the switch."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, idx, ent, description)
         self._api = hass.data[DOMAIN][entry.entry_id][API]
         self._api_data = hass.data[DOMAIN][entry.entry_id]
-
-        self._idx = idx
-        self._ent = ent
-        self.entity_description = description
         _LOGGER.debug("init switch %s", ent)
-        appl_type = self.coordinator.data[self._ent][self.entity_description.type_key]
-        if appl_type == "":
-            appl_type = self.coordinator.data[self._ent][
-                "ident|deviceIdentLabel|techType"
-            ]
-        self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self.entity_description.key}-{self._ent}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ent)},
-            serial_number=self._ent,
-            name=appl_type,
-            manufacturer=MANUFACTURER,
-            model=self.coordinator.data[self._ent]["ident|deviceIdentLabel|techType"],
-        )
 
     @property
     def is_on(self):


### PR DESCRIPTION
Uses a common entity class to reuse code for `_attr_device_info` and other common attributes like `_attr_has_entity_name`, `_attr_unique_id`, `ent`, ...


- [x] real world test