### PR TITLE
Use translation placeholders for plate numbers

### DIFF
--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -161,7 +161,7 @@ async def async_setup_entry(
                     key="plate",
                     data_tag=f"state|plateStep|{plate_no}|value_raw",
                     icon="mdi:stove",
-                    translation_key="plate_{plate_no}",
+                    translation_key="plate",
                     translation_placeholders={"plate_no": f"{plate_no+1}"}
                     zone=plate_no,
                     native_min_value=0.0,

--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -162,7 +162,7 @@ async def async_setup_entry(
                     data_tag=f"state|plateStep|{plate_no}|value_raw",
                     icon="mdi:stove",
                     translation_key="plate",
-                    translation_placeholders={"plate_no": f"{plate_no+1}"}
+                    translation_placeholders={"plate_no": f"{plate_no+1}"},
                     zone=plate_no,
                     native_min_value=0.0,
                     native_max_value=10.0,

--- a/custom_components/miele/number.py
+++ b/custom_components/miele/number.py
@@ -161,7 +161,8 @@ async def async_setup_entry(
                     key="plate",
                     data_tag=f"state|plateStep|{plate_no}|value_raw",
                     icon="mdi:stove",
-                    translation_key=f"plate_{plate_no+1}",
+                    translation_key="plate_{plate_no}",
+                    translation_placeholders={"plate_no": f"{plate_no+1}"}
                     zone=plate_no,
                     native_min_value=0.0,
                     native_max_value=10.0,

--- a/custom_components/miele/translations/en.json
+++ b/custom_components/miele/translations/en.json
@@ -125,27 +125,6 @@
     "number": {
       "plate": {
         "name": "Plate {plate_no}"
-      },
-      "plate_0": {
-        "name": "Plate 0"
-      },
-      "plate_1": {
-        "name": "Plate 1"
-      },
-      "plate_2": {
-        "name": "Plate 2"
-      },
-      "plate_3": {
-        "name": "Plate 3"
-      },
-      "plate_4": {
-        "name": "Plate 4"
-      },
-      "plate_5": {
-        "name": "Plate 5"
-      },
-      "plate_6": {
-        "name": "Plate 6"
       }
     },
     "sensor": {

--- a/custom_components/miele/translations/en.json
+++ b/custom_components/miele/translations/en.json
@@ -123,6 +123,9 @@
       }
     },
     "number": {
+      "plate": {
+        "name": "Plate {plate_no}"
+      },
       "plate_0": {
         "name": "Plate 0"
       },


### PR DESCRIPTION
Removes the need for separate localized strings:

<img width="567" alt="Bildschirmfoto 2024-08-06 um 14 19 43" src="https://github.com/user-attachments/assets/93fb428c-1c02-4d33-a3b7-5fe60afeeac0">

- [ ] real world test