### PR TITLE
Add semi-professional washing machines

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -175,6 +175,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not coordinator.last_update_success:
         await coordinator.async_config_entry_first_refresh()
     serialnumbers = list(coordinator.data.keys())
+    if len(serialnumbers) == 0:
+        _LOGGER.warning("No devices found in API for this account")
+    else:
+        _LOGGER.debug("Miele devices in API account: %s", serialnumbers)
 
     miele_api = hass.data[DOMAIN][entry.entry_id][API]
     for serial in serialnumbers:

--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -54,6 +54,7 @@ from .devcap import (  # noqa: F401
     TEST_ACTION_21,
     TEST_ACTION_23,
     TEST_DATA_1,
+    TEST_DATA_3,
     TEST_DATA_4,
     TEST_DATA_7,
     TEST_DATA_12,
@@ -204,6 +205,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _callback_update_data(data) -> None:
         # data["1223001"] = TEST_DATA_1
+        # data["1223003"] = TEST_DATA_3
         # data["1223004"] = TEST_DATA_4
         # data["1223007"] = TEST_DATA_7
         # data["1223012"] = TEST_DATA_12
@@ -290,6 +292,7 @@ async def get_coordinator(
         hass.data[DOMAIN][entry.entry_id]["retries_401"] = 0
         flat_result: dict = {}
         # result["1223001"] = TEST_DATA_1
+        # result["1223003"] = TEST_DATA_3
         # result["1223004"] = TEST_DATA_4
         # result["1223007"] = TEST_DATA_7
         # result["1223012"] = TEST_DATA_12

--- a/custom_components/miele/binary_sensor.py
+++ b/custom_components/miele/binary_sensor.py
@@ -48,6 +48,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -78,6 +79,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -113,6 +115,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -152,6 +155,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -188,6 +192,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -224,6 +229,7 @@ BINARY_SENSOR_TYPES: Final[tuple[MieleBinarySensorDefinition, ...]] = (
     MieleBinarySensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,

--- a/custom_components/miele/button.py
+++ b/custom_components/miele/button.py
@@ -51,6 +51,7 @@ BUTTON_TYPES: Final[tuple[MieleButtonDefinition, ...]] = (
     MieleButtonDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -73,6 +74,7 @@ BUTTON_TYPES: Final[tuple[MieleButtonDefinition, ...]] = (
     MieleButtonDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,

--- a/custom_components/miele/devcap.py
+++ b/custom_components/miele/devcap.py
@@ -160,6 +160,93 @@ TEST_DATA_1 = {
     },
 }
 
+TEST_DATA_3 = {
+    "ident": {
+        "type": {
+            "key_localized": "Device type",
+            "value_raw": 3,
+            "value_localized": "",
+        },
+        "deviceName": "",
+        "protocolVersion": 4,
+        "deviceIdentLabel": {
+            "fabNumber": "<fabnumber03>",
+            "fabIndex": "00",
+            "techType": "PWM507",
+            "matNumber": "",
+            "swids": ["000"],
+        },
+        "xkmIdentLabel": {
+            "techType": "EK037",
+            "releaseVersion": "03.94",
+        },
+    },
+    "state": {
+        "ProgramID": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program name",
+        },
+        "status": {
+            "value_raw": 1,
+            "value_localized": "Off",
+            "key_localized": "status",
+        },
+        "programType": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program type",
+        },
+        "programPhase": {
+            "value_raw": 0,
+            "value_localized": "",
+            "key_localized": "Program phase",
+        },
+        "remainingTime": [0, 0],
+        "startTime": [0, 0],
+        "targetTemperature": [
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "temperature": [
+            {"value_raw": 2500, "value_localized": 25.0, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+            {"value_raw": -32768, "value_localized": None, "unit": "Celsius"},
+        ],
+        "signalInfo": False,
+        "signalFailure": False,
+        "signalDoor": True,
+        "remoteEnable": {
+            "fullRemoteControl": True,
+            "smartGrid": False,
+            "mobileStart": False,
+        },
+        "ambientLight": None,
+        "light": None,
+        "elapsedTime": [0, 0],
+        "spinningSpeed": {
+            "unit": "rpm",
+            "value_raw": None,
+            "value_localized": None,
+            "key_localized": "Spin speed",
+        },
+        "dryingStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Drying level",
+        },
+        "ventilationStep": {
+            "value_raw": None,
+            "value_localized": "",
+            "key_localized": "Fan level",
+        },
+        "plateStep": [],
+        "ecoFeedback": None,
+        "batteryLevel": None,
+    },
+}
+
 TEST_DATA_4 = {
     "ident": {
         "type": {

--- a/custom_components/miele/sensor.py
+++ b/custom_components/miele/sensor.py
@@ -268,6 +268,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -315,6 +316,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -345,6 +347,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -375,6 +378,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -404,6 +408,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.WASHER_DRYER,
         ],
         description=MieleSensorDescription(
@@ -435,6 +440,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -462,6 +468,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -492,6 +499,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -519,6 +527,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -613,6 +622,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,
@@ -649,6 +659,7 @@ SENSOR_TYPES: Final[tuple[MieleSensorDefinition, ...]] = (
     MieleSensorDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,

--- a/custom_components/miele/switch.py
+++ b/custom_components/miele/switch.py
@@ -85,6 +85,7 @@ SWITCH_TYPES: Final[tuple[MieleSwitchDefinition, ...]] = (
     MieleSwitchDefinition(
         types=[
             MieleAppliance.WASHING_MACHINE,
+            MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
             MieleAppliance.TUMBLE_DRYER,
             MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
             MieleAppliance.DISHWASHER,


### PR DESCRIPTION
The semi-professional series is not officially supported by the Miele public API.
But to improve the user experience we enable some entities for these appliances anyway.