### PR TITLE
Change timeout used

### DIFF
--- a/custom_components/miele/__init__.py
+++ b/custom_components/miele/__init__.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.timeouts
 from datetime import timedelta
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
 import logging
 
 from aiohttp import ClientResponseError
-import async_timeout
 import flatdict
 import voluptuous as vol
 
@@ -201,7 +201,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     miele_api = hass.data[DOMAIN][entry.entry_id][API]
     for serial in serialnumbers:
         try:
-            async with async_timeout.timeout(API_READ_TIMEOUT):
+            async with asyncio.timeout(API_READ_TIMEOUT):
                 res = await miele_api.request(
                     "GET",
                     f"/devices/{serial}/actions",
@@ -289,7 +289,7 @@ async def get_coordinator(
     async def async_fetch():
         miele_api = hass.data[DOMAIN][entry.entry_id][API]
         try:
-            async with async_timeout.timeout(API_READ_TIMEOUT):
+            async with asyncio.timeout(API_READ_TIMEOUT):
                 res = await miele_api.request(
                     "GET",
                     f"/devices?language={hass.config.language}",

--- a/custom_components/miele/diagnostics.py
+++ b/custom_components/miele/diagnostics.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio.timeouts
 from typing import Any
-
-import async_timeout
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
@@ -76,7 +75,7 @@ async def async_get_device_diagnostics(
                     key, {}
                 )
             miele_api = hass.data[DOMAIN][config_entry.entry_id][API]
-            async with async_timeout.timeout(API_READ_TIMEOUT):
+            async with asyncio.timeout(API_READ_TIMEOUT):
                 res = await miele_api.request(
                     "GET",
                     f"/devices/{key}/programs",


### PR DESCRIPTION
async_timeout is deprecated in favour of built-in asyncio_timeouts since python >= 3.11